### PR TITLE
Enable option to set skipSchemas

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.5 (2025-03-14)
+--------------------------
+Enable option to set skipSchemas (#13)
+
 Version 0.1.4 (2025-03-10)
 --------------------------
 Enable webhook monitoring (#10)

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ module "snowflake_streaming_loader" {
 | <a name="input_scale_up_cooldown_sec"></a> [scale\_up\_cooldown\_sec](#input\_scale\_up\_cooldown\_sec) | Time (in seconds) until another scale-up action can occur | `number` | `180` | no |
 | <a name="input_scale_up_cpu_threshold_percentage"></a> [scale\_up\_cpu\_threshold\_percentage](#input\_scale\_up\_cpu\_threshold\_percentage) | The average CPU percentage that must be exceeded to scale-up | `number` | `60` | no |
 | <a name="input_scale_up_eval_minutes"></a> [scale\_up\_eval\_minutes](#input\_scale\_up\_eval\_minutes) | The number of consecutive minutes that the threshold must be breached to scale-up | `number` | `5` | no |
+| <a name="input_skip_schemas"></a> [skip\_schemas](#input\_skip\_schemas) | A list of schemas that won't be loaded to Snowflake | `list(string)` | `[]` | no |
 | <a name="input_snowflake_loader_role"></a> [snowflake\_loader\_role](#input\_snowflake\_loader\_role) | Snowflake role used by loader to perform loading | `string` | `""` | no |
 | <a name="input_ssh_ip_allowlist"></a> [ssh\_ip\_allowlist](#input\_ssh\_ip\_allowlist) | The list of CIDR ranges to allow SSH traffic from | `list(any)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | The tags to append to this resource | `map(string)` | `{}` | no |
@@ -159,7 +160,6 @@ module "snowflake_streaming_loader" {
 | <a name="input_user_provided_id"></a> [user\_provided\_id](#input\_user\_provided\_id) | An optional unique identifier to identify the telemetry events emitted by this stack | `string` | `""` | no |
 | <a name="input_webhook_endpoint"></a> [webhook\_endpoint](#input\_webhook\_endpoint) | HTTP endpoint to report monitoring alerts and heartbeats | `string` | `""` | no |
 | <a name="input_webhook_heartbeat"></a> [webhook\_heartbeat](#input\_webhook\_heartbeat) | How often to send the heartbeat event | `string` | `"5 minutes"` | no |
-| <a name="input_skip_schemas"></a> [skip\_schemas](#input\_skip\_schemas) | A list of schemas that won't be loaded to Snowflake | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ module "snowflake_streaming_loader" {
 
   webhook_endpoint  = ""
   webhook_heartbeat = "5 minutes"
+
+  skip_schemas = [
+    "iglu:com.acme/skipped1/jsonschema/1-0-0",
+    "iglu:com.acme/skipped2/jsonschema/1-0-*",
+    "iglu:com.acme/skipped3/jsonschema/1-*-*",
+    "iglu:com.acme/skipped4/jsonschema/*-*-*"
+  ]
 }
 ```
 
@@ -152,6 +159,7 @@ module "snowflake_streaming_loader" {
 | <a name="input_user_provided_id"></a> [user\_provided\_id](#input\_user\_provided\_id) | An optional unique identifier to identify the telemetry events emitted by this stack | `string` | `""` | no |
 | <a name="input_webhook_endpoint"></a> [webhook\_endpoint](#input\_webhook\_endpoint) | HTTP endpoint to report monitoring alerts and heartbeats | `string` | `""` | no |
 | <a name="input_webhook_heartbeat"></a> [webhook\_heartbeat](#input\_webhook\_heartbeat) | How often to send the heartbeat event | `string` | `"5 minutes"` | no |
+| <a name="input_skip_schemas"></a> [skip\_schemas](#input\_skip\_schemas) | A list of schemas that won't be loaded to Snowflake | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   module_name    = "snowflake-streaming-loader-ec2"
-  module_version = "0.1.4"
+  module_version = "0.1.5"
 
   app_name    = "snowflake-loader"
   app_version = var.app_version

--- a/main.tf
+++ b/main.tf
@@ -293,6 +293,8 @@ locals {
     telemetry_auto_gen_id      = join("", module.telemetry.*.auto_generated_id)
     telemetry_module_name      = local.module_name
     telemetry_module_version   = local.module_version
+
+    skip_schemas = jsonencode(var.skip_schemas)
   })
 
   user_data = templatefile("${path.module}/templates/user-data.sh.tmpl", {

--- a/templates/config.hocon.tmpl
+++ b/templates/config.hocon.tmpl
@@ -27,6 +27,8 @@
     }
   }
 
+  "skipSchemas": ${skip_schemas}
+
   "monitoring": {
 %{ if webhook_endpoint != "" ~}
     "webhook": {

--- a/variables.tf
+++ b/variables.tf
@@ -260,3 +260,11 @@ variable "webhook_heartbeat" {
   type        = string
   default     = "5 minutes"
 }
+
+# --- Other configuration options
+
+variable "skip_schemas" {
+  description = "A list of schemas that won't be loaded to Snowflake"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Adds the optional variable `skip_schemas` to allow specifying the schemas that won't be loaded to Snowflake.